### PR TITLE
Task#112852

### DIFF
--- a/l10n_es_aeat_mod390/__openerp__.py
+++ b/l10n_es_aeat_mod390/__openerp__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'AEAT modelo 390',
-    'version': '8.0.1.0',
+    'version': '8.0.1.1',
     'category': "Localisation/Accounting",
     'author': "Tecnativa,"
               "Odoo Community Association (OCA)",

--- a/l10n_es_aeat_mod390/data/aeat_export_mod390_2021_sub06_data.xml
+++ b/l10n_es_aeat_mod390/data/aeat_export_mod390_2021_sub06_data.xml
@@ -424,7 +424,7 @@
         <field name="sequence">36</field>
         <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
         <field name="name">10. Volumen de operaciones - Operaciones sujetas con inversión del sujeto pasivo [125]</field>
-        <field name="fixed_value">0</field>
+        <field name="expression">${object.tax_lines.filtered(lambda r: r.field_number == 125).amount}</field>
         <field name="export_type">float</field>
         <field name="apply_sign" eval="True"/>
         <field name="size">17</field>

--- a/l10n_es_aeat_mod390/data/tax_code_map_mod390_data.xml
+++ b/l10n_es_aeat_mod390/data/tax_code_map_mod390_data.xml
@@ -675,7 +675,7 @@
         <field name="field_type">base</field>
         <field name="sum_type">both</field>
         <field name="inverse" eval="False"/>
-        <field name="tax_codes" eval="[(6, False, [ref('l10n_es.account_tax_code_template_EYOA'), ref('l10n_es.account_tax_code_template_ONSOCIDSPQOEDAD')])]"/>
+        <field name="tax_codes" eval="[(6, False, [ref('l10n_es.account_tax_code_template_EYOA')])]"/>
     </record>
 
     <record id="aeat_mod390_map_line_105" model="aeat.mod.map.tax.code.line">
@@ -696,7 +696,7 @@
         <field name="move_type">regular</field>
         <field name="field_type">base</field>
         <field name="sum_type">both</field>
-        <field name="inverse" eval="True"/>
+        <field name="inverse" eval="False"/>
         <field name="tax_codes" eval="[(6, False, [ref('l10n_es.account_tax_code_template_REBI05'), ref('l10n_es.account_tax_code_template_REBI014'), ref('l10n_es.account_tax_code_template_REBI52')])]"/>
     </record>
 
@@ -853,6 +853,19 @@
         <field name="inverse" eval="False" />
     </record>
 
+    <record id="aeat_mod390_map_line_125" model="aeat.mod.map.tax.code.line">
+        <field name="map_parent_id" ref="aeat_mod390_map" />
+        <field name="field_number">125</field>
+        <field name="name">Operaciones sujetas con inversión del sujeto pasivo</field>
+        <field name="move_type">regular</field>
+        <field name="field_type">amount</field>
+        <field name="sum_type">both</field>
+        <field name="inverse" eval="False" />
+        <field
+            name="tax_codes"
+            eval="[(6, False, [ref('l10n_es.account_tax_code_template_VISP')])]"
+        />
+    </record>
 
     <!-- CASILLAS QUE SE HAN PUESTO A MANO A PARTIR DE LA 67-->
 <!--     <record id="aeat_mod390_map_line_196" model="l10n.es.aeat.map.tax.line">

--- a/l10n_es_aeat_mod390/models/mod390.py
+++ b/l10n_es_aeat_mod390/models/mod390.py
@@ -575,7 +575,7 @@ class L10nEsAeatMod390Report(models.Model):
                 report.tax_lines.filtered(
                     lambda x: x.field_number in (
                         99, 653, 103, 104, 105, 110, 112, 100, 101, 102, 227,
-                        228,
+                        228, 125,
                     )
                 ).mapped('amount')
             ) - sum(


### PR DESCRIPTION
Cambios modelo 390.
Añadimos casilla 125 al mapeo con el impuesto VISP, y añadimos que se rellene en el fichero de exportación.
Quitamos ONSOCIDSPQOEDAD de la casilla 104
Añadimos resultado de la casilla 125 al cálculo de la casilla 108
Modificamos signo para la casilla 102, el inverse=False
Modificamos versión para que se les actualice, ya que de esto no se saca master
